### PR TITLE
Combine Entry, File and Directory in a struct

### DIFF
--- a/src/fs/file/file_type.rs
+++ b/src/fs/file/file_type.rs
@@ -1,0 +1,62 @@
+//! ## File type
+//!
+//! represents the file type
+
+/**
+ * MIT License
+ *
+ * remotefs - Copyright (c) 2021 Christian Visintin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/// Describes the file type (directory, regular file or symlink)
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+pub enum FileType {
+    /// A directory
+    Directory,
+    /// Regular file
+    File,
+    /// Symbolic link. If the file is a symlink pointing to a directory,
+    /// this will be still considered a Symlink.
+    Symlink,
+}
+
+impl Default for FileType {
+    fn default() -> Self {
+        Self::File
+    }
+}
+
+impl FileType {
+    /// Returns whether file is a directory
+    pub fn is_dir(&self) -> bool {
+        matches!(self, Self::Directory)
+    }
+
+    /// Returns whether file is a regular file
+    pub fn is_file(&self) -> bool {
+        matches!(self, Self::File)
+    }
+
+    /// Returns whether file is symlink
+    pub fn is_symlink(&self) -> bool {
+        matches!(self, Self::Symlink)
+    }
+}

--- a/src/fs/file/file_type.rs
+++ b/src/fs/file/file_type.rs
@@ -25,6 +25,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+use std::fs::FileType as StdFileType;
 
 /// Describes the file type (directory, regular file or symlink)
 #[derive(Clone, Debug, PartialEq, Eq, Hash)]
@@ -58,5 +59,38 @@ impl FileType {
     /// Returns whether file is symlink
     pub fn is_symlink(&self) -> bool {
         matches!(self, Self::Symlink)
+    }
+}
+
+impl From<StdFileType> for FileType {
+    fn from(t: StdFileType) -> Self {
+        if t.is_symlink() {
+            Self::Symlink
+        } else if t.is_dir() {
+            Self::Directory
+        } else {
+            Self::File
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+
+    use super::*;
+
+    use pretty_assertions::assert_eq;
+
+    #[test]
+    fn should_check_file_type() {
+        assert_eq!(FileType::Directory.is_dir(), true);
+        assert_eq!(FileType::Directory.is_file(), false);
+        assert_eq!(FileType::Directory.is_symlink(), false);
+        assert_eq!(FileType::File.is_dir(), false);
+        assert_eq!(FileType::File.is_file(), true);
+        assert_eq!(FileType::File.is_symlink(), false);
+        assert_eq!(FileType::Symlink.is_dir(), false);
+        assert_eq!(FileType::Symlink.is_file(), false);
+        assert_eq!(FileType::Symlink.is_symlink(), true);
     }
 }

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -38,7 +38,7 @@ mod welcome;
 
 // -- export
 pub use errors::{RemoteError, RemoteErrorType, RemoteResult};
-pub use file::{Directory, Entry, File, Metadata, UnixPex, UnixPexClass};
+pub use file::{FileType, FsEntity, Metadata, UnixPex, UnixPexClass};
 pub use welcome::Welcome;
 
 /// Defines the methods which must be implemented in order to setup a Remote file system
@@ -62,10 +62,10 @@ pub trait RemoteFs {
     fn change_dir(&mut self, dir: &Path) -> RemoteResult<PathBuf>;
 
     /// List directory entries at specified `path`
-    fn list_dir(&mut self, path: &Path) -> RemoteResult<Vec<Entry>>;
+    fn list_dir(&mut self, path: &Path) -> RemoteResult<Vec<FsEntity>>;
 
     /// Stat file at specified `path` and return Entry
-    fn stat(&mut self, path: &Path) -> RemoteResult<Entry>;
+    fn stat(&mut self, path: &Path) -> RemoteResult<FsEntity>;
 
     /// Set metadata for file at specifieed `path`
     fn setstat(&mut self, path: &Path, metadata: Metadata) -> RemoteResult<()>;
@@ -96,21 +96,23 @@ pub trait RemoteFs {
             let path = crate::utils::path::absolutize(&self.pwd()?, path);
             debug!("Removing {}...", path.display());
             let entry = self.stat(path.as_path())?;
-            match entry {
-                Entry::File(_) => self.remove_file(entry.path()),
-                Entry::Directory(d) => {
-                    // list dir
-                    debug!("{} is a directory; removing all directory entries", d.name);
-                    let directory_content = self.list_dir(d.path.as_path())?;
-                    for entry in directory_content.iter() {
-                        self.remove_dir_all(entry.path())?;
-                    }
-                    trace!(
-                        "Removed all files in {}; removing directory",
-                        d.path.display()
-                    );
-                    self.remove_dir(d.path.as_path())
+            if entry.is_dir() {
+                // list dir
+                debug!(
+                    "{} is a directory; removing all directory entries",
+                    entry.name()
+                );
+                let directory_content = self.list_dir(entry.path())?;
+                for entry in directory_content.iter() {
+                    self.remove_dir_all(entry.path())?;
                 }
+                trace!(
+                    "Removed all files in {}; removing directory",
+                    entry.path().display()
+                );
+                self.remove_dir(entry.path())
+            } else {
+                self.remove_file(entry.path())
             }
         } else {
             Err(RemoteError::new(RemoteErrorType::NotConnected))
@@ -257,7 +259,7 @@ pub trait RemoteFs {
 
     /// Find files from current directory (in all subdirectories) whose name matches the provided search
     /// Search supports wildcards ('?', '*')
-    fn find(&mut self, search: &str) -> RemoteResult<Vec<Entry>> {
+    fn find(&mut self, search: &str) -> RemoteResult<Vec<FsEntity>> {
         match self.is_connected() {
             true => {
                 // Starting from current directory, iter dir
@@ -276,8 +278,8 @@ pub trait RemoteFs {
     ///
     /// NOTE: DON'T RE-IMPLEMENT THIS FUNCTION, unless the file transfer provides a faster way to do so
     /// NOTE: don't call this method from outside; consider it as private
-    fn iter_search(&mut self, dir: &Path, filter: &WildMatch) -> RemoteResult<Vec<Entry>> {
-        let mut drained: Vec<Entry> = Vec::new();
+    fn iter_search(&mut self, dir: &Path, filter: &WildMatch) -> RemoteResult<Vec<FsEntity>> {
+        let mut drained: Vec<FsEntity> = Vec::new();
         // Scan directory
         match self.list_dir(dir) {
             Ok(entries) => {
@@ -287,19 +289,16 @@ pub trait RemoteFs {
                 - if is file: check if it matches `filter`
                     - if it matches `filter`: push to to filter
                 */
-                for entry in entries.iter() {
-                    match entry {
-                        Entry::Directory(dir) => {
-                            // If directory name, matches wildcard, push it to drained
-                            if filter.matches(dir.name.as_str()) {
-                                drained.push(Entry::Directory(dir.clone()));
-                            }
-                            drained.append(&mut self.iter_search(dir.path.as_path(), filter)?);
+                for entry in entries.into_iter() {
+                    if entry.is_dir() {
+                        // If directory name, matches wildcard, push it to drained
+                        if filter.matches(entry.name().as_str()) {
+                            drained.push(entry.clone());
                         }
-                        Entry::File(file) => {
-                            if filter.matches(file.name.as_str()) {
-                                drained.push(Entry::File(file.clone()));
-                            }
+                        drained.append(&mut self.iter_search(entry.path(), filter)?);
+                    } else {
+                        if filter.matches(entry.name().as_str()) {
+                            drained.push(entry);
                         }
                     }
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 extern crate log;
 
 // -- export
-pub use fs::{Directory, Entry, File, RemoteError, RemoteErrorType, RemoteFs, RemoteResult};
+pub use fs::{FsEntity, RemoteError, RemoteErrorType, RemoteFs, RemoteResult};
 // -- modules
 pub mod fs;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@
 extern crate log;
 
 // -- export
-pub use fs::{FsEntity, RemoteError, RemoteErrorType, RemoteFs, RemoteResult};
+pub use fs::{File, RemoteError, RemoteErrorType, RemoteFs, RemoteResult};
 // -- modules
 pub mod fs;
 

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -57,18 +57,17 @@ impl RemoteFs for MockRemoteFs {
     }
 
     #[allow(unused)]
-    fn list_dir(&mut self, path: &std::path::Path) -> crate::RemoteResult<Vec<crate::Entry>> {
+    fn list_dir(&mut self, path: &std::path::Path) -> crate::RemoteResult<Vec<crate::FsEntity>> {
         Ok(vec![])
     }
 
     #[allow(unused)]
-    fn stat(&mut self, path: &std::path::Path) -> crate::RemoteResult<crate::Entry> {
-        Ok(crate::Entry::File(crate::File {
-            name: "foo".to_string(),
+    fn stat(&mut self, path: &std::path::Path) -> crate::RemoteResult<crate::FsEntity> {
+        Ok(crate::FsEntity {
             path: std::path::PathBuf::from("/foo"),
-            extension: None,
             metadata: crate::fs::Metadata::default(),
-        }))
+            type_: crate::fs::FileType::File,
+        })
     }
 
     #[allow(unused)]

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -57,16 +57,15 @@ impl RemoteFs for MockRemoteFs {
     }
 
     #[allow(unused)]
-    fn list_dir(&mut self, path: &std::path::Path) -> crate::RemoteResult<Vec<crate::FsEntity>> {
+    fn list_dir(&mut self, path: &std::path::Path) -> crate::RemoteResult<Vec<crate::File>> {
         Ok(vec![])
     }
 
     #[allow(unused)]
-    fn stat(&mut self, path: &std::path::Path) -> crate::RemoteResult<crate::FsEntity> {
-        Ok(crate::FsEntity {
+    fn stat(&mut self, path: &std::path::Path) -> crate::RemoteResult<crate::File> {
+        Ok(crate::File {
             path: std::path::PathBuf::from("/foo"),
             metadata: crate::fs::Metadata::default(),
-            type_: crate::fs::FileType::File,
         })
     }
 


### PR DESCRIPTION
# 3 - Combine the File and Directory struct

Fixes #3 

## Description

- I merged removed Entry and replaced it with `File`.
- I added `type_` as `FileType` to `Metadata` in order to match against dir/file/symlink.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] The changes I've made are Windows, MacOS, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

- [x] Unit tests

- [ ] regression test: ...
