### PR TITLE
Implement Seek trait for readers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Released on ??
 - Merged `File`, `Directory` and `Entry` into a unique struct called `File`. File types (symlink, file, directory) are now differentiated by the `file_type` attribute in `Metadata`.
 - `find` method is now optional, via the `find` feature (enabled by default)
 - Implemented `From` trait for `Metadata`.
+- `create` and `append` will now return a `WriteStream` instead of a box, which will contain the inner stream which supports `Write` and may support `Seek` (according to the protocol).
+- `read` will now return a `ReadStream` instead of a box, which will contain the inner stream which supports `Read` and may support `Seek` (according to the protocol).
 
 ## 0.1.1
 

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -35,11 +35,13 @@ use wildmatch::WildMatch;
 // -- modules
 mod errors;
 mod file;
+pub mod stream;
 mod welcome;
 
 // -- export
 pub use errors::{RemoteError, RemoteErrorType, RemoteResult};
 pub use file::{File, FileType, Metadata, UnixPex, UnixPexClass};
+pub use stream::{ReadStream, WriteStream};
 pub use welcome::Welcome;
 
 /// Defines the methods which must be implemented in order to setup a Remote file system
@@ -143,7 +145,7 @@ pub trait RemoteFs {
     ///
     /// metadata should be the same of the local file.
     /// In some protocols, such as `scp` the `size` field is used to define the transfer size (required by the protocol)
-    fn append(&mut self, path: &Path, metadata: &Metadata) -> RemoteResult<Box<dyn Write>>;
+    fn append(&mut self, path: &Path, metadata: &Metadata) -> RemoteResult<WriteStream>;
 
     /// Create file at path for write.
     /// If the file already exists, its content will be overwritten
@@ -152,10 +154,10 @@ pub trait RemoteFs {
     ///
     /// metadata should be the same of the local file.
     /// In some protocols, such as `scp` the `size` field is used to define the transfer size (required by the protocol)
-    fn create(&mut self, path: &Path, metadata: &Metadata) -> RemoteResult<Box<dyn Write>>;
+    fn create(&mut self, path: &Path, metadata: &Metadata) -> RemoteResult<WriteStream>;
 
     /// Open file at specified path for read.
-    fn open(&mut self, path: &Path) -> RemoteResult<Box<dyn Read>>;
+    fn open(&mut self, path: &Path) -> RemoteResult<ReadStream>;
 
     /// Finalize `create_file` and `append_file` methods.
     /// This method must be implemented only if necessary; in case you don't need it, just return `Ok(())`
@@ -166,7 +168,7 @@ pub trait RemoteFs {
     /// ### Default implementation
     ///
     /// By default this function returns already `Ok(())`
-    fn on_written(&mut self, _writable: Box<dyn Write>) -> RemoteResult<()> {
+    fn on_written(&mut self, _writable: WriteStream) -> RemoteResult<()> {
         Ok(())
     }
 
@@ -179,7 +181,7 @@ pub trait RemoteFs {
     /// ### Default implementation
     ///
     /// By default this function returns already `Ok(())`
-    fn on_read(&mut self, _readable: Box<dyn Read>) -> RemoteResult<()> {
+    fn on_read(&mut self, _readable: ReadStream) -> RemoteResult<()> {
         Ok(())
     }
 

--- a/src/fs/stream.rs
+++ b/src/fs/stream.rs
@@ -1,0 +1,169 @@
+//! ## Stream
+//!
+//! this module exposes the streams returned by create, append and open methods
+
+/**
+ * MIT License
+ *
+ * remotefs - Copyright (c) 2021 Christian Visintin
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+use std::io::{Error as IoError, ErrorKind as IoErrorKind, Read, Seek, Write};
+
+// -- read stream
+
+/// A trait which combines `io::Read` and `io::Seek` together
+pub trait ReadAndSeek: Read + Seek {}
+
+/// The stream returned by RemoteFs to read a file from the remote server
+pub struct ReadStream {
+    stream: StreamReader,
+}
+
+/// The kind of stream contained in the stream. Can be Read only or Read + Seek
+enum StreamReader {
+    Read(Box<dyn Read>),
+    ReadAndSeek(Box<dyn ReadAndSeek>),
+}
+
+impl ReadStream {
+    /// Instantiates a new `ReadStream` which supports the `Read` trait only.
+    pub fn read(reader: Box<dyn Read>) -> Self {
+        Self {
+            stream: StreamReader::Read(reader),
+        }
+    }
+
+    /// Instantiates a new `ReadStream` which supports both `Read` and `Seek` traits.
+    pub fn read_and_seek(reader: Box<dyn ReadAndSeek>) -> Self {
+        Self {
+            stream: StreamReader::ReadAndSeek(reader),
+        }
+    }
+}
+
+impl Read for ReadStream {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        self.stream.read(buf)
+    }
+}
+
+impl Seek for ReadStream {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        self.stream.seek(pos)
+    }
+}
+
+impl Read for StreamReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Read(r) => r.read(buf),
+            Self::ReadAndSeek(r) => r.read(buf),
+        }
+    }
+}
+
+impl Seek for StreamReader {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        match self {
+            Self::Read(_) => Err(IoError::new(
+                IoErrorKind::Unsupported, // TODO: change to `NotSeekable` when stable <https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html#variant.NotSeekable>
+                "the read stream for this protocol, doesn't support Seek operation",
+            )),
+            Self::ReadAndSeek(s) => s.seek(pos),
+        }
+    }
+}
+
+// -- write stream
+
+/// A trait which combines `io::Write` and `io::Seek` together
+pub trait WriteAndSeek: Write + Seek {}
+
+/// The stream returned by RemoteFs to write a file from the remote server
+pub struct WriteStream {
+    stream: StreamWriter,
+}
+
+/// The kind of stream contained in the stream. Can be Write only or Write + Seek
+enum StreamWriter {
+    Write(Box<dyn Write>),
+    WriteAndSeek(Box<dyn WriteAndSeek>),
+}
+
+impl WriteStream {
+    /// Instantiates a new `WriteStream` which supports the `Write` trait only.
+    pub fn write(writer: Box<dyn Write>) -> Self {
+        Self {
+            stream: StreamWriter::Write(writer),
+        }
+    }
+
+    /// Instantiates a new `WriteStream` which supports both `Write` and `Seek` traits.
+    pub fn write_and_seek(writer: Box<dyn WriteAndSeek>) -> Self {
+        Self {
+            stream: StreamWriter::WriteAndSeek(writer),
+        }
+    }
+}
+
+impl Write for WriteStream {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.stream.write(buf)
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.stream.flush()
+    }
+}
+
+impl Seek for WriteStream {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        self.stream.seek(pos)
+    }
+}
+
+impl Write for StreamWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        match self {
+            Self::Write(w) => w.write(buf),
+            Self::WriteAndSeek(w) => w.write(buf),
+        }
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        match self {
+            Self::Write(w) => w.flush(),
+            Self::WriteAndSeek(w) => w.flush(),
+        }
+    }
+}
+
+impl Seek for StreamWriter {
+    fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
+        match self {
+            Self::Write(_) => Err(IoError::new(
+                IoErrorKind::Unsupported, // TODO: change to `NotSeekable` when stable <https://doc.rust-lang.org/stable/std/io/enum.ErrorKind.html#variant.NotSeekable>
+                "the read stream for this protocol, doesn't support Seek operation",
+            )),
+            Self::WriteAndSeek(s) => s.seek(pos),
+        }
+    }
+}

--- a/src/mock/mod.rs
+++ b/src/mock/mod.rs
@@ -131,7 +131,7 @@ impl RemoteFs for MockRemoteFs {
         &mut self,
         path: &std::path::Path,
         metadata: &crate::fs::Metadata,
-    ) -> crate::RemoteResult<Box<dyn std::io::Write>> {
+    ) -> crate::RemoteResult<crate::fs::WriteStream> {
         Err(crate::RemoteError::new(
             crate::RemoteErrorType::UnsupportedFeature,
         ))
@@ -142,14 +142,14 @@ impl RemoteFs for MockRemoteFs {
         &mut self,
         path: &std::path::Path,
         metadata: &crate::fs::Metadata,
-    ) -> crate::RemoteResult<Box<dyn std::io::Write>> {
+    ) -> crate::RemoteResult<crate::fs::WriteStream> {
         Err(crate::RemoteError::new(
             crate::RemoteErrorType::UnsupportedFeature,
         ))
     }
 
     #[allow(unused)]
-    fn open(&mut self, path: &std::path::Path) -> crate::RemoteResult<Box<dyn std::io::Read>> {
+    fn open(&mut self, path: &std::path::Path) -> crate::RemoteResult<crate::fs::ReadStream> {
         Err(crate::RemoteError::new(
             crate::RemoteErrorType::UnsupportedFeature,
         ))


### PR DESCRIPTION
# ISSUE 9 - Implement Seek trait for readers

Fixes #9 

## Description

- `create` and `append` will now return a `WriteStream` instead of a box, which will contain the inner stream which supports `Write` and may support `Seek` (according to the protocol).
- `read` will now return a `ReadStream` instead of a box, which will contain the inner stream which supports `Read` and may support `Seek` (according to the protocol).

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] The changes I've made are Windows, MacOS, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

/
