### PR TITLE
fix: update readme to reflect the latest version for smb & ssh client libs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,13 @@ To use an existing client, you must add them to your `Cargo.toml`, along with re
 - [smb](https://github.com/veeso/remotefs-rs-smb)
 
   ```toml
-  remotefs-smb = "^0.1.0"
+  remotefs-smb = "^0.2.0"
   ```
 
 - [ssh](https://github.com/veeso/remotefs-rs-ssh)
 
   ```toml
-  remotefs-ssh = "^0.1.0"
+  remotefs-ssh = "^0.2.0"
   ```
 
 ---


### PR DESCRIPTION
# 27 - update readme to reflect the latest version of smb & ssh client libs.

Fixes #27 

## Description

Updated `README.md` to include the latest version of both [remotefs-rs-smb](https://github.com/veeso/remotefs-rs-smb) & [remotefs-rs-ssh](https://github.com/veeso/remotefs-rs-ssh) client library.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I formatted the code with `cargo fmt`
- [ ] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] The changes I've made are Windows, MacOS, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
